### PR TITLE
Enhancing tumor loss

### DIFF
--- a/losses.py
+++ b/losses.py
@@ -6,55 +6,11 @@ import torch
 import torch.nn as nn
 from torch.nn import functional as F
 
-def agg_dice_score(preds, targets):
-    ''' Gives Dice score for sub-regions which are evaluated in the
-    competition.
-    '''
-    channel_shape = preds[:, 0, :, :, :].size()
-
-    agg = torch.zeros(preds.size())
-    et = torch.zeros(channel_shape)
-    et[torch.where(preds[:, 2, :, :, :] > 0.5)] = 1
-    et = et.unsqueeze(1)
-
-    wt = torch.zeros(channel_shape)
-    wt[torch.where((preds[:, 0, :, :, :] > 0.5) | 
-    (preds[:, 1, :, :, :] > 0.5) | 
-    (preds[:, 2, :, :, :] > 0.5) )] = 1
-    wt = wt.unsqueeze(1)
-
-    tc = torch.zeros(channel_shape)
-    tc[torch.where((preds[:, 0, :, :, :] > 0.5) | (preds[:, 2, :, :, :] > 0.5) )] = 1
-    tc = tc.unsqueeze(1)
-
-    agg_preds = torch.cat((et, wt, tc), 1)
-
-    et_target = torch.zeros(channel_shape)
-    et_target[torch.where(targets[:, 2, :, :, :] > 0.5)] = 1
-    et_target = et_target.unsqueeze(1) 
-
-    wt_target = torch.zeros(channel_shape)
-    wt_target[torch.where((targets[:, 0, :, :, :] > 0.5) | 
-    (targets[:, 1, :, :, :] > 0.5) | (targets[:, 2, :, :, :] > 0.5) )] = 1
-    wt_target = wt_target.unsqueeze(1)
-
-    tc_target = torch.zeros(channel_shape)
-    tc_target[torch.where((targets[:, 0, :, :, :] > 0.5) | 
-    (targets[:, 2, :, :, :] > 0.5) )] = 1
-    tc_target = tc_target.unsqueeze(1)
-
-    agg_targets = torch.cat((et_target, wt_target, tc_target), 1)
-
-    return dice_score(agg_preds, agg_targets)
-
 
 def dice_score(preds, targets):
-    # have to cast to float because of issues with amp
-    preds_fp = preds.float()
-    targets_fp = targets.float()
-    num = 2*torch.einsum('bcijk, bcijk ->bc', [preds_fp, targets_fp])
-    denom = torch.einsum('bcijk, bcijk -> bc', [preds_fp, preds_fp]) +\
-        torch.einsum('bcijk, bcijk -> bc', [targets_fp, targets_fp]) + 1e-8
+    num = 2*torch.einsum('bcijk, bcijk ->bc', [preds, targets])
+    denom = torch.einsum('bcijk, bcijk -> bc', [preds, preds]) +\
+        torch.einsum('bcijk, bcijk -> bc', [targets, targets]) + 1e-8
     proportions = torch.div(num, denom) 
     return torch.einsum('bc->c', proportions)
 
@@ -99,6 +55,50 @@ class AvgDiceLoss(nn.Module):
         avg_dice = torch.einsum('c->', proportions) / (target.shape[0]*target.shape[1])
         return 1 - avg_dice
 
+class AvgDiceEnhanceLoss(nn.Module):
+    def __init__(self, device):
+        super(AvgDiceEnhanceLoss, self).__init__()
+        self.device = device
+        self.avgdice = AvgDiceLoss()
+    
+    def _enhancing_loss(self, et_prob, ce_ratio):
+        ''' penalizes et predicted for voxels which are not enhancing 
+        by computing the false positive rate of enhancing tumor predictions
+        to voxels which are enhancing.'''
+
+    
+        # is this a reference? does it change the original tensor?
+        # turns out it did and it was a problem
+        ce_ratio_ones = torch.zeros(ce_ratio.size()).to(self.device)
+        ce_ratio_ones[ce_ratio<0] = 0 
+        ce_ratio_ones[ce_ratio>0] = 1
+
+        et_pred = torch.zeros(et_prob.size()).to(self.device)
+        et_pred[et_prob>0] = 1
+        fp = torch.einsum('bijk, bijk->b', [et_pred, et_pred])\
+               - torch.einsum('bijk, bijk->b', [et_pred, ce_ratio])
+
+        # (this is probably a convoluted way to) compute the number of true negatives
+        tn_mat = torch.ones(et_pred.size()).to(self.device) 
+        tn_mat[et_pred == 0] = 0
+        tn_mat[ce_ratio == 0] = 0
+        tn_num = torch.einsum('bijk, bijk->b', [tn_mat, tn_mat])
+
+        # false postive ratio
+        fp_rat = fp / (fp + tn_num + 1e-32)
+        return fp_rat
+
+ 
+    def forward(self, preds, targets):
+        # preds dim BxCxHxWxD
+        ad_loss = self.avgdice(preds, targets)
+        enh_loss = self._enhancing_loss(
+                torch.squeeze(preds[:, 0, :, :, :]), 
+                torch.squeeze(targets['src'][:, -1, :, :, :])
+                )
+        enh_loss_batch_avg = torch.einsum('b->', enh_loss) / len(enh_loss)
+        return 0.5*ad_loss + 0.5*enh_loss_batch_avg
+
 class CascadeAvgDiceLoss(nn.Module):
     def __init__(self):
         super(CascadeAvgDiceLoss, self).__init__()
@@ -110,4 +110,48 @@ class CascadeAvgDiceLoss(nn.Module):
         return 0.33*(self.coarse_loss(output['coarse'], targets)\
                 + self.biline_loss(output['biline'], targets)\
                 + self.deconv_loss(output['deconv'], targets))
+
+
+def agg_dice_score(preds, targets):
+    ''' Gives Dice score for sub-regions which are evaluated in the
+    competition.
+    '''
+    channel_shape = preds[:, 0, :, :, :].size()
+
+    agg = torch.zeros(preds.size())
+    et = torch.zeros(channel_shape)
+    et[torch.where(preds[:, 2, :, :, :] > 0.5)] = 1
+    et = et.unsqueeze(1)
+
+    wt = torch.zeros(channel_shape)
+    wt[torch.where((preds[:, 0, :, :, :] > 0.5) | 
+    (preds[:, 1, :, :, :] > 0.5) | 
+    (preds[:, 2, :, :, :] > 0.5) )] = 1
+    wt = wt.unsqueeze(1)
+
+    tc = torch.zeros(channel_shape)
+    tc[torch.where((preds[:, 0, :, :, :] > 0.5) | (preds[:, 2, :, :, :] > 0.5) )] = 1
+    tc = tc.unsqueeze(1)
+
+    agg_preds = torch.cat((et, wt, tc), 1)
+
+    et_target = torch.zeros(channel_shape)
+    et_target[torch.where(targets[:, 2, :, :, :] > 0.5)] = 1
+    et_target = et_target.unsqueeze(1) 
+
+    wt_target = torch.zeros(channel_shape)
+    wt_target[torch.where((targets[:, 0, :, :, :] > 0.5) | 
+    (targets[:, 1, :, :, :] > 0.5) | (targets[:, 2, :, :, :] > 0.5) )] = 1
+    wt_target = wt_target.unsqueeze(1)
+
+    tc_target = torch.zeros(channel_shape)
+    tc_target[torch.where((targets[:, 0, :, :, :] > 0.5) | 
+    (targets[:, 2, :, :, :] > 0.5) )] = 1
+    tc_target = tc_target.unsqueeze(1)
+
+    agg_targets = torch.cat((et_target, wt_target, tc_target), 1)
+
+    return dice_score(agg_preds, agg_targets)
+
+
 

--- a/models/models.py
+++ b/models/models.py
@@ -42,6 +42,7 @@ class ResNetBlock(nn.Module):
         out += residual
         return out
 
+
 class Encoder(nn.Module):
     def __init__(self, input_channels=4):
         super(Encoder, self).__init__()
@@ -112,14 +113,13 @@ class Decoder(nn.Module):
         sp1 = self.block13(sp1)
         #sp1 = self.block14(sp1)
         output = self.sig(self.cf_final(sp1))
-
+        
         return output
      
-# deprecated
 class MonoUNet(nn.Module):
-    def __init__(self):
+    def __init__(self, input_channels=4):
         super(MonoUNet, self).__init__()
-        self.encoder = Encoder()
+        self.encoder = Encoder(input_channels=input_channels)
         self.decoder = Decoder()
 
     def forward(self, x):

--- a/utils.py
+++ b/utils.py
@@ -219,6 +219,7 @@ def validate(model, loss, dataloader, device, debug=False):
             loss_total += loss(output, {'target':target, 'src':src}) 
             if isinstance(model, models.MonoUNet): 
                 dice_total += dice_score(output, target)
+            if isinstance(model, vaereg.VAEReg):
                 #print(f'dice_total: {dice_total}')
                 dice_total += dice_score(output['seg_map'], target)
 


### PR DESCRIPTION
- removed single letter CL args because they make it harder to add
new options
- added an enchancement feature to the model based on the assumption
that if there is enhancing tumor there then
the image must be enhancing, i.e. t1ce/t1 > 1
- got rid of the last of the batchgenerators leftovers
- took the float cast out of dice score. this may have been needed for
mixed precision since we're not using it right now it's just additional
ops for no reason.
- added AvgDiceEnhanceLoss which adds an additional term to the loss function
for discouraging predicting et on pixels where t1ce/t1 <= 0
- got rid of agg dice score because it's unused.
- encoder is no longer hardcoded for 4 input channels.
- argument --enhance_feat added to parser for turning the enhancing tumor
feature on
- cleared a bunch of commented code out of train